### PR TITLE
recoil/gunplay rework intial

### DIFF
--- a/src/server/progs.src
+++ b/src/server/progs.src
@@ -7,7 +7,7 @@
 #define VALVE
 #define CSTRIKE
 #define BULLETPENETRATION
-#define BULLETPATTERNS
+//#define BULLETPATTERNS
 
 #includelist
 ../../../src/shared/fteextensions.qc

--- a/src/shared/player.h
+++ b/src/shared/player.h
@@ -154,8 +154,10 @@ class player:NSClientPlayer
 	PREDICTED_INT(mode_glock18)
 	PREDICTED_INT(mode_temp)
 
-	PREDICTED_INT(cs_shotmultiplier)
+	PREDICTED_FLOAT(cs_shotmultiplier)
 	PREDICTED_FLOAT(cs_shottime)
+	PREDICTED_FLOAT(cs_prev_hor_rec)
+	PREDICTED_INT(cs_hor_rec_sign)
 
 	PREDICTED_FLOAT(anim_top)
 	PREDICTED_FLOAT(anim_top_time)
@@ -400,7 +402,8 @@ player::ReceiveEntity(float flIsNew, float flChanged)
 	READENTITY_BYTE(mode_temp, PLAYER_AMMO3)
 	READENTITY_BYTE(cs_shotmultiplier, PLAYER_CSTIMERS)
 	READENTITY_FLOAT(cs_shottime, PLAYER_CSTIMERS)
-
+	READENTITY_FLOAT(cs_prev_hor_rec, PLAYER_CSTIMERS)
+	READENTITY_BYTE(cs_hor_rec_sign, PLAYER_CSTIMERS)
 	if (flChanged & PLAYER_AMMO1 || flChanged & PLAYER_AMMO2 || flChanged & PLAYER_AMMO3) {
 		Weapons_AmmoUpdate(this);
 		HUD_AmmoNotify_Check(this);
@@ -463,6 +466,8 @@ player::PredictPreFrame(void)
 	SAVE_STATE(mode_temp)
 	SAVE_STATE(cs_shotmultiplier)
 	SAVE_STATE(cs_shottime)
+	SAVE_STATE(cs_prev_hor_rec)
+	SAVE_STATE(cs_hor_rec_sign)
 	SAVE_STATE(anim_top)
 	SAVE_STATE(anim_top_time)
 	SAVE_STATE(anim_top_delay)
@@ -523,6 +528,8 @@ player::PredictPostFrame(void)
 	ROLL_BACK(mode_temp)
 	ROLL_BACK(cs_shotmultiplier)
 	ROLL_BACK(cs_shottime)
+	ROLL_BACK(cs_prev_hor_rec)
+	ROLL_BACK(cs_hor_rec_sign)
 	ROLL_BACK(anim_top)
 	ROLL_BACK(anim_top_time)
 	ROLL_BACK(anim_top_delay)
@@ -588,6 +595,8 @@ player::EvaluateEntity(void)
 	EVALUATE_FIELD(mode_temp, PLAYER_AMMO3)
 	EVALUATE_FIELD(cs_shotmultiplier, PLAYER_CSTIMERS)
 	EVALUATE_FIELD(cs_shottime, PLAYER_CSTIMERS)
+	EVALUATE_FIELD(cs_prev_hor_rec, PLAYER_CSTIMERS)
+	EVALUATE_FIELD(cs_hor_rec_sign, PLAYER_CSTIMERS)
 }
 
 /*
@@ -657,6 +666,8 @@ player::SendEntity(entity ePEnt, float flChanged)
 	SENDENTITY_BYTE(mode_temp, PLAYER_AMMO3)
 	SENDENTITY_BYTE(cs_shotmultiplier, PLAYER_CSTIMERS)
 	SENDENTITY_FLOAT(cs_shottime, PLAYER_CSTIMERS)
+	SENDENTITY_FLOAT(cs_prev_hor_rec, PLAYER_CSTIMERS)
+	SENDENTITY_BYTE(cs_hor_rec_sign, PLAYER_CSTIMERS)
 
 	return (1);
 }

--- a/src/shared/player.h
+++ b/src/shared/player.h
@@ -201,10 +201,30 @@ class player:NSClientPlayer
 #endif
 };
 
+float punchangle_recovery(float punchangle) {
+	return 0.05 * (-0.2 * pow(1.2, fabs(punchangle)) + 4);
+}
 void
 player::Physics_InputPostMove(void)
 {
-	super::Physics_InputPostMove();
+	//start of this function is taken from super::Physics_InputPostMove
+	float punch;
+	/* timers, these are predicted and shared across client and server */
+	w_attack_next = max(0, w_attack_next - input_timelength);
+	w_idle_next = max(0, w_idle_next - input_timelength);
+	weapontime += input_timelength;
+	punch = max(0, 1.0f - (input_timelength * 4));
+	if (punchangle[0] < 0) {
+		punchangle[0] += punchangle_recovery(punchangle[0]);
+	}
+	punchangle[1] *= .98;
+	punchangle[2] *= .99;
+
+	/* player animation code */
+	UpdatePlayerAnimation(input_timelength);
+
+	RemoveFlags(FL_FROZEN);
+	ProcessInput();
 
 #ifdef SERVER
 	if (g_cs_gamestate == GAME_FREEZE) {

--- a/src/shared/w_ak47.qc
+++ b/src/shared/w_ak47.qc
@@ -152,8 +152,8 @@ w_ak47_primary(player pl)
 		return;
 	}
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 120,2.5);
 	pl.ak47_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -181,11 +181,14 @@ w_ak47_primary(player pl)
 	dmg = Skill_GetValue("plr_ak47_dmg", 36);
 	TraceAttack_SetRangeModifier(2.375); /* 18 units!!! */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,1.1);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_AK47, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,1.1);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_ak47.fire");
 #endif
 
-	pl.w_attack_next = 0.0955f;
+	Cstrike_ShotMultiplierAdd(pl, 2, 1.1);
+	pl.w_attack_next = 0.0975f;
 	pl.w_idle_next = pl.w_attack_next;
 }
 

--- a/src/shared/w_ak47.qc
+++ b/src/shared/w_ak47.qc
@@ -153,7 +153,7 @@ w_ak47_primary(player pl)
 	}
 
 
-	float accuracy = Cstrike_CalculateAccuracy(pl, 120,2.5);
+	float accuracy = Cstrike_CalculateAccuracy(pl, 110,2.5);
 	pl.ak47_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -181,13 +181,13 @@ w_ak47_primary(player pl)
 	dmg = Skill_GetValue("plr_ak47_dmg", 36);
 	TraceAttack_SetRangeModifier(2.375); /* 18 units!!! */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,1.1);
+	Cstrike_BulletRecoil_ApplyPre(pl,1);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_AK47, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,1.1);
+	Cstrike_BulletRecoil_ApplyPost(pl,1);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_ak47.fire");
 #endif
 
-	Cstrike_ShotMultiplierAdd(pl, 2, 1.1);
+	Cstrike_ShotMultiplierAdd(pl, 1.5, 1.05);
 	pl.w_attack_next = 0.0975f;
 	pl.w_idle_next = pl.w_attack_next;
 }

--- a/src/shared/w_aug.qc
+++ b/src/shared/w_aug.qc
@@ -118,8 +118,8 @@ w_aug_primary(player pl)
 		return;
 	}
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 215);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 15,3)*pl.viewzoom;
 	pl.aug_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -147,10 +147,13 @@ w_aug_primary(player pl)
 	dmg = Skill_GetValue("plr_aug_dmg", 32);
 	TraceAttack_SetRangeModifier(2.125);
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,1.15);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_AUG, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,1.15);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_aug.fire");
 #endif
 
+	Cstrike_ShotMultiplierAdd(pl, 0.7, 1.1);
 	if (pl.viewzoom == 1.0f) {
 		pl.w_attack_next = 0.0825f;
 	} else {

--- a/src/shared/w_aug.qc
+++ b/src/shared/w_aug.qc
@@ -119,7 +119,7 @@ w_aug_primary(player pl)
 	}
 
 
-	float accuracy = Cstrike_CalculateAccuracy(pl, 15,3)*pl.viewzoom;
+	float accuracy = Cstrike_CalculateAccuracy(pl, 45,3)*pl.viewzoom;
 	pl.aug_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -147,13 +147,13 @@ w_aug_primary(player pl)
 	dmg = Skill_GetValue("plr_aug_dmg", 32);
 	TraceAttack_SetRangeModifier(2.125);
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,1.15);
+	Cstrike_BulletRecoil_ApplyPre(pl,1.03);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_AUG, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,1.15);
+	Cstrike_BulletRecoil_ApplyPost(pl,1.03);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_aug.fire");
 #endif
 
-	Cstrike_ShotMultiplierAdd(pl, 0.7, 1.1);
+	Cstrike_ShotMultiplierAdd(pl, 0.7f, 1.1f);
 	if (pl.viewzoom == 1.0f) {
 		pl.w_attack_next = 0.0825f;
 	} else {

--- a/src/shared/w_awp.qc
+++ b/src/shared/w_awp.qc
@@ -209,7 +209,7 @@ w_awp_primary(player pl)
 		return;
 	}
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
+	Cstrike_ShotMultiplierAdd(pl, 1, 1);
 	float accuracy = Cstrike_CalculateAccuracy(pl, -1);
 	pl.awp_mag--;
 

--- a/src/shared/w_deagle.qc
+++ b/src/shared/w_deagle.qc
@@ -180,9 +180,9 @@ w_deagle_primary(player pl)
 	dmg = Skill_GetValue("plr_deagle_dmg", 54);
 	TraceAttack_SetRangeModifier(1.875); /* 14 but not 15 */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,0.5);
+	Cstrike_BulletRecoil_ApplyPre(pl,0.5);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_DEAGLE, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,0.5);
+	Cstrike_BulletRecoil_ApplyPost(pl,0.5);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_deagle.fire");
 #endif
 

--- a/src/shared/w_deagle.qc
+++ b/src/shared/w_deagle.qc
@@ -149,8 +149,8 @@ w_deagle_primary(player pl)
 	if (!pl.deagle_mag)
 		return;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 30,2.2)+0.005;
 	int dmg;
 	pl.deagle_mag--;
 
@@ -180,12 +180,15 @@ w_deagle_primary(player pl)
 	dmg = Skill_GetValue("plr_deagle_dmg", 54);
 	TraceAttack_SetRangeModifier(1.875); /* 14 but not 15 */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,0.5);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_DEAGLE, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,0.5);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_deagle.fire");
 #endif
 
+	Cstrike_ShotMultiplierAdd(pl, 30, .3);
 	pl.gflags |= GF_SEMI_TOGGLED;
-	pl.w_attack_next = 0.15f;
+	pl.w_attack_next = 0.2f;
 	pl.w_idle_next = pl.w_attack_next;
 }
 

--- a/src/shared/w_deagle.qc
+++ b/src/shared/w_deagle.qc
@@ -150,7 +150,7 @@ w_deagle_primary(player pl)
 		return;
 
 
-	float accuracy = Cstrike_CalculateAccuracy(pl, 30,2.2)+0.005;
+	float accuracy = Cstrike_CalculateAccuracy(pl, 25,2.2)+0.005;
 	int dmg;
 	pl.deagle_mag--;
 
@@ -186,7 +186,7 @@ w_deagle_primary(player pl)
 	Sound_Play(pl, CHAN_WEAPON, "weapon_deagle.fire");
 #endif
 
-	Cstrike_ShotMultiplierAdd(pl, 30, .3);
+	Cstrike_ShotMultiplierAdd(pl, 20, .25);
 	pl.gflags |= GF_SEMI_TOGGLED;
 	pl.w_attack_next = 0.2f;
 	pl.w_idle_next = pl.w_attack_next;

--- a/src/shared/w_elites.qc
+++ b/src/shared/w_elites.qc
@@ -252,9 +252,9 @@ w_elites_primary(player pl)
 	dmg = Skill_GetValue("plr_elites_dmg", 45);
 	TraceAttack_SetRangeModifier(1.875); /* 14 but not 15 */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,.9f);
+	Cstrike_BulletRecoil_ApplyPre(pl,.9f);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_ELITES, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,.9f);
+	Cstrike_BulletRecoil_ApplyPost(pl,.9f);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_elites.fire");
 #endif
 	Cstrike_ShotMultiplierAdd(pl, 3, .85);

--- a/src/shared/w_elites.qc
+++ b/src/shared/w_elites.qc
@@ -177,8 +177,8 @@ w_elites_primary(player pl)
 
 	pl.mode_temp = 1 - pl.mode_temp;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 150,1)+0.002;
 	int dmg = 0;
 	pl.elites_mag--;
 
@@ -252,12 +252,14 @@ w_elites_primary(player pl)
 	dmg = Skill_GetValue("plr_elites_dmg", 45);
 	TraceAttack_SetRangeModifier(1.875); /* 14 but not 15 */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,.9f);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_ELITES, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,.9f);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_elites.fire");
 #endif
-
+	Cstrike_ShotMultiplierAdd(pl, 3, .85);
 	pl.gflags |= GF_SEMI_TOGGLED;
-	pl.w_attack_next = 0.15f;
+	pl.w_attack_next = 0.13f;
 	pl.w_idle_next = pl.w_attack_next;
 }
 

--- a/src/shared/w_fiveseven.qc
+++ b/src/shared/w_fiveseven.qc
@@ -120,8 +120,8 @@ w_fiveseven_primary(player pl)
 		return;
 	}
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl,200,1.4)+ 0.0055f;
 	int dmg = 0;
 	pl.fiveseven_mag--;
 
@@ -151,12 +151,14 @@ w_fiveseven_primary(player pl)
 	dmg = Skill_GetValue("plr_fiveseven_dmg", 25);
 	TraceAttack_SetRangeModifier(1.875); /* 14 but not 15 */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,0.5f);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_FIVESEVEN, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,0.5f);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_fiveseven.fire");
 #endif
-
+	Cstrike_ShotMultiplierAdd(pl, 10, .4);
 	pl.gflags |= GF_SEMI_TOGGLED;
-	pl.w_attack_next = 0.15f;
+	pl.w_attack_next = 0.155f;
 	pl.w_idle_next = pl.w_attack_next;
 }
 

--- a/src/shared/w_fiveseven.qc
+++ b/src/shared/w_fiveseven.qc
@@ -151,9 +151,9 @@ w_fiveseven_primary(player pl)
 	dmg = Skill_GetValue("plr_fiveseven_dmg", 25);
 	TraceAttack_SetRangeModifier(1.875); /* 14 but not 15 */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,0.5f);
+	Cstrike_BulletRecoil_ApplyPre(pl,0.5f);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_FIVESEVEN, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,0.5f);
+	Cstrike_BulletRecoil_ApplyPost(pl,0.5f);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_fiveseven.fire");
 #endif
 	Cstrike_ShotMultiplierAdd(pl, 10, .4);

--- a/src/shared/w_g3sg1.qc
+++ b/src/shared/w_g3sg1.qc
@@ -116,7 +116,7 @@ w_g3sg1_primary(player pl)
 		return;
 	}
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
+	Cstrike_ShotMultiplierAdd(pl, 1, 1);
 	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
 	pl.g3sg1_mag--;
 

--- a/src/shared/w_glock18.qc
+++ b/src/shared/w_glock18.qc
@@ -142,14 +142,17 @@ w_glock18_primary(player pl)
 		shotcount = pl.glock18_mag;
 
 	for (int i = 0; i < shotcount; i ++) {
-		Cstrike_ShotMultiplierAdd(pl, 1);
-		float accuracy = Cstrike_CalculateAccuracy(pl, (pl.mode_glock18) ? 175 : 200);
+		
+		float accuracy = Cstrike_CalculateAccuracy(pl, (pl.mode_glock18) ? 75 : 120,1.2);
+		accuracy += 0.0035;
 		pl.glock18_mag--;
 #ifdef SERVER
 		dmg = Skill_GetValue("plr_glock18_dmg", 25);
 		TraceAttack_SetRangeModifier(1.25); /* penetrates 9 units, but not 10 */
 		TraceAttack_SetPenetrationPower(1);
+		g_CstrikeBulletRecoil.ApplyPre(pl,0.5);
 		TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_GLOCK18, "Impact.BigShot");
+		g_CstrikeBulletRecoil.ApplyPost(pl,0.5);
 #endif
 	}
 
@@ -170,7 +173,7 @@ w_glock18_primary(player pl)
 		} else {
 			Weapons_ViewAnimation(pl, GLOCK_SHOOT);
 		}
-		pl.w_attack_next = 0.15f;
+		pl.w_attack_next = 0.13f;
 	}
 
 	if (pl.flags & FL_CROUCHING)
@@ -189,6 +192,7 @@ w_glock18_primary(player pl)
 	}
 #endif
 
+	Cstrike_ShotMultiplierAdd(pl, 2, .7);
 	pl.gflags |= GF_SEMI_TOGGLED;
 	pl.w_idle_next = pl.w_attack_next + 1.0f;
 }

--- a/src/shared/w_glock18.qc
+++ b/src/shared/w_glock18.qc
@@ -150,9 +150,9 @@ w_glock18_primary(player pl)
 		dmg = Skill_GetValue("plr_glock18_dmg", 25);
 		TraceAttack_SetRangeModifier(1.25); /* penetrates 9 units, but not 10 */
 		TraceAttack_SetPenetrationPower(1);
-		g_CstrikeBulletRecoil.ApplyPre(pl,0.5);
+		Cstrike_BulletRecoil_ApplyPre(pl,0.6);
 		TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_GLOCK18, "Impact.BigShot");
-		g_CstrikeBulletRecoil.ApplyPost(pl,0.5);
+		Cstrike_BulletRecoil_ApplyPost(pl,0.6);
 #endif
 	}
 

--- a/src/shared/w_m3.qc
+++ b/src/shared/w_m3.qc
@@ -206,7 +206,7 @@ w_m3_primary(player pl)
 #endif
 
 	for (int i = 0; i < 9; i++) {
-		Cstrike_ShotMultiplierAdd(pl, 1);
+		Cstrike_ShotMultiplierAdd(pl, 1, 1);
 		pl.punchangle[0] = -4 * (9 / 6);
 #ifdef SERVER
 		TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [random(-1,1) * 0.1,random(-1,1) * 0.05], WEAPON_M3, "Impact.BigShot");

--- a/src/shared/w_m4a1.qc
+++ b/src/shared/w_m4a1.qc
@@ -189,9 +189,9 @@ w_m4a1_primary(player pl)
 	dmg = Skill_GetValue("plr_m4a1_dmg", 33);
 	TraceAttack_SetRangeModifier(2.125);
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,1);
+	Cstrike_BulletRecoil_ApplyPre(pl,1);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg,  [accuracy,accuracy], WEAPON_M4A1, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,1);
+	Cstrike_BulletRecoil_ApplyPost(pl,1);
 #endif
 
 	Cstrike_ShotMultiplierAdd(pl, 1, 1);

--- a/src/shared/w_m4a1.qc
+++ b/src/shared/w_m4a1.qc
@@ -86,7 +86,7 @@ int
 w_m4a1_pickup(player pl, int new, int startammo)
 {
 #ifdef SERVER
-
+	Cstrike_ShotMultiplierUpdate(pl);
 	if (new) {
 		if (startammo == -1)
 			pl.m4a1_mag = 30;
@@ -133,8 +133,9 @@ w_m4a1_primary(player pl)
 		return;
 	}
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 220);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 150, 3);
+//	accuracy += pl.cs_shotmultiplier*pl.cs_shotmultiplier / 500;
 	pl.m4a1_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -188,9 +189,12 @@ w_m4a1_primary(player pl)
 	dmg = Skill_GetValue("plr_m4a1_dmg", 33);
 	TraceAttack_SetRangeModifier(2.125);
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,1);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg,  [accuracy,accuracy], WEAPON_M4A1, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,1);
 #endif
 
+	Cstrike_ShotMultiplierAdd(pl, 1, 1);
 	pl.w_attack_next = 0.0875f;
 	pl.w_idle_next = 2.0f;
 }
@@ -227,6 +231,7 @@ w_m4a1_reload(player pl)
 		return;
 	if (!pl.ammo_556mm)
 		return;
+	Cstrike_ShotMultiplierUpdate(pl);
 
 	if (pl.mode_m4a1 == 1)
 		Weapons_ViewAnimation(pl, M4A1_RELOAD);
@@ -241,7 +246,7 @@ w_m4a1_reload(player pl)
 		player pl = (player)self;
 		Weapons_ReloadWeapon(pl, player::m4a1_mag, player::ammo_556mm, 30);
 	}
-
+	
 	pl.think = w_weapon_reload_done;
 	pl.nextthink = time + pl.w_attack_next - 0.1f;
 #endif

--- a/src/shared/w_mac10.qc
+++ b/src/shared/w_mac10.qc
@@ -118,7 +118,7 @@ w_mac10_primary(player pl)
 	}
 
 
-	float accuracy = Cstrike_CalculateAccuracy(pl, 80,0.9)+0.011;
+	float accuracy = Cstrike_CalculateAccuracy(pl, 80,0.7)+0.009f;
 	pl.mac10_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -146,9 +146,9 @@ w_mac10_primary(player pl)
 	dmg = Skill_GetValue("plr_mac10_dmg", 29);
 	TraceAttack_SetRangeModifier(1.25); /* 9, but not 10 */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,1.2);
+	g_CstrikeBulletRecoil.ApplyPre(pl,1.125);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_MAC10, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,1.2);
+	g_CstrikeBulletRecoil.ApplyPost(pl,1.125);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_mac10.fire");
 #endif
 

--- a/src/shared/w_mac10.qc
+++ b/src/shared/w_mac10.qc
@@ -117,8 +117,8 @@ w_mac10_primary(player pl)
 		return;
 	}
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 80,0.9)+0.011;
 	pl.mac10_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -146,10 +146,13 @@ w_mac10_primary(player pl)
 	dmg = Skill_GetValue("plr_mac10_dmg", 29);
 	TraceAttack_SetRangeModifier(1.25); /* 9, but not 10 */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,1.2);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_MAC10, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,1.2);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_mac10.fire");
 #endif
 
+	Cstrike_ShotMultiplierAdd(pl, .8, .9);
 	pl.w_attack_next = 0.07f;
 	pl.w_idle_next = pl.w_attack_next;
 }

--- a/src/shared/w_mac10.qc
+++ b/src/shared/w_mac10.qc
@@ -146,9 +146,9 @@ w_mac10_primary(player pl)
 	dmg = Skill_GetValue("plr_mac10_dmg", 29);
 	TraceAttack_SetRangeModifier(1.25); /* 9, but not 10 */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,1.125);
+	Cstrike_BulletRecoil_ApplyPre(pl,1.125);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_MAC10, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,1.125);
+	Cstrike_BulletRecoil_ApplyPost(pl,1.125);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_mac10.fire");
 #endif
 

--- a/src/shared/w_mp5.qc
+++ b/src/shared/w_mp5.qc
@@ -115,8 +115,8 @@ w_mp5_primary(player pl)
 	if (!pl.mp5_mag)
 		return;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 220);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl,100,1)+0.0065f;
 	pl.mp5_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -144,10 +144,13 @@ w_mp5_primary(player pl)
 	dmg = Skill_GetValue("plr_mp5_dmg", 26);
 	TraceAttack_SetRangeModifier(1.25); /* 9 units but not 10 */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,.7f);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_MP5, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,.7f);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_mp5.fire");
 #endif
 
+	Cstrike_ShotMultiplierAdd(pl, .5f, 1.5f);
 	pl.w_attack_next = 0.08f;
 	pl.w_idle_next = pl.w_attack_next;
 }

--- a/src/shared/w_mp5.qc
+++ b/src/shared/w_mp5.qc
@@ -144,9 +144,9 @@ w_mp5_primary(player pl)
 	dmg = Skill_GetValue("plr_mp5_dmg", 26);
 	TraceAttack_SetRangeModifier(1.25); /* 9 units but not 10 */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,.7f);
+	Cstrike_BulletRecoil_ApplyPre(pl,.7f);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_MP5, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,.7f);
+	Cstrike_BulletRecoil_ApplyPost(pl,.7f);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_mp5.fire");
 #endif
 

--- a/src/shared/w_mp5.qc
+++ b/src/shared/w_mp5.qc
@@ -116,7 +116,7 @@ w_mp5_primary(player pl)
 		return;
 
 
-	float accuracy = Cstrike_CalculateAccuracy(pl,100,1)+0.0065f;
+	float accuracy = Cstrike_CalculateAccuracy(pl,100,1)+0.004f;
 	pl.mp5_mag--;
 
 	int r = (float)input_sequence % 3;

--- a/src/shared/w_p228.qc
+++ b/src/shared/w_p228.qc
@@ -117,8 +117,8 @@ w_p228_primary(player pl)
 	if (!pl.p228_mag)
 		return;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 200,1.6) + 0.005f;
 	int dmg = 0;
 	pl.p228_mag--;
 
@@ -151,12 +151,15 @@ w_p228_primary(player pl)
 	dmg = Skill_GetValue("plr_p228_dmg", 40);
 	TraceAttack_SetRangeModifier(1.5); /* penetrates 11, but not 12 units */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,1.2);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_P228, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,1.2);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_p228.fire");
 #endif
+	Cstrike_ShotMultiplierAdd(pl, 6, 0.5f);
 
 	pl.gflags |= GF_SEMI_TOGGLED;
-	pl.w_attack_next = 0.15f;
+	pl.w_attack_next = 0.145f;
 	pl.w_idle_next = pl.w_attack_next;
 }
 

--- a/src/shared/w_p228.qc
+++ b/src/shared/w_p228.qc
@@ -118,7 +118,7 @@ w_p228_primary(player pl)
 		return;
 
 
-	float accuracy = Cstrike_CalculateAccuracy(pl, 200,1.6) + 0.005f;
+	float accuracy = Cstrike_CalculateAccuracy(pl, 200,1.6) + 0.004f;
 	int dmg = 0;
 	pl.p228_mag--;
 
@@ -151,15 +151,15 @@ w_p228_primary(player pl)
 	dmg = Skill_GetValue("plr_p228_dmg", 40);
 	TraceAttack_SetRangeModifier(1.5); /* penetrates 11, but not 12 units */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,1.2);
+	Cstrike_BulletRecoil_ApplyPre(pl,1.2);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_P228, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,1.2);
+	Cstrike_BulletRecoil_ApplyPost(pl,1.2);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_p228.fire");
 #endif
 	Cstrike_ShotMultiplierAdd(pl, 6, 0.5f);
 
 	pl.gflags |= GF_SEMI_TOGGLED;
-	pl.w_attack_next = 0.145f;
+	pl.w_attack_next = 0.1425f;
 	pl.w_idle_next = pl.w_attack_next;
 }
 

--- a/src/shared/w_p90.qc
+++ b/src/shared/w_p90.qc
@@ -144,9 +144,9 @@ w_p90_primary(player pl)
 	dmg = Skill_GetValue("plr_p90_dmg", 26);
 	TraceAttack_SetRangeModifier(1.875); /* 9 but not 10 */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,1);
+	Cstrike_BulletRecoil_ApplyPre(pl,1);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_P90, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,1);
+	Cstrike_BulletRecoil_ApplyPost(pl,1);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_p90.fire");
 #endif
 

--- a/src/shared/w_p90.qc
+++ b/src/shared/w_p90.qc
@@ -115,8 +115,8 @@ w_p90_primary(player pl)
 	if (!pl.p90_mag)
 		return;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 175);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 50,1)+0.0055;
 	pl.p90_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -144,10 +144,13 @@ w_p90_primary(player pl)
 	dmg = Skill_GetValue("plr_p90_dmg", 26);
 	TraceAttack_SetRangeModifier(1.875); /* 9 but not 10 */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,1);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_P90, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,1);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_p90.fire");
 #endif
 
+	Cstrike_ShotMultiplierAdd(pl, 1.1, 1.1);
 	pl.w_attack_next = 0.07f;
 	pl.w_idle_next = pl.w_attack_next;
 }

--- a/src/shared/w_para.qc
+++ b/src/shared/w_para.qc
@@ -114,7 +114,7 @@ w_para_primary(player pl)
 	if (!pl.para_mag)
 		return;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
+	Cstrike_ShotMultiplierAdd(pl, 1, 1);
 	float accuracy = Cstrike_CalculateAccuracy(pl, 175);
 	pl.para_mag--;
 

--- a/src/shared/w_scout.qc
+++ b/src/shared/w_scout.qc
@@ -174,7 +174,7 @@ w_scout_primary(player pl)
 		return;
 	}
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
+	Cstrike_ShotMultiplierAdd(pl, 1, 1);
 	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
 	pl.scout_mag--;
 

--- a/src/shared/w_sg550.qc
+++ b/src/shared/w_sg550.qc
@@ -114,7 +114,7 @@ w_sg550_primary(player pl)
 	if (!pl.sg550_mag)
 		return;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
+	Cstrike_ShotMultiplierAdd(pl, 1, 1);
 	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
 	pl.sg550_mag--;
 

--- a/src/shared/w_sg552.qc
+++ b/src/shared/w_sg552.qc
@@ -144,9 +144,9 @@ w_sg552_primary(player pl)
 	dmg = Skill_GetValue("plr_sg552_dmg", 33);
 	TraceAttack_SetRangeModifier(2.125);
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,1);
+	Cstrike_BulletRecoil_ApplyPre(pl,1);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_SG552, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,1);
+	Cstrike_BulletRecoil_ApplyPost(pl,1);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_sg552.fire");
 #endif
 

--- a/src/shared/w_sg552.qc
+++ b/src/shared/w_sg552.qc
@@ -115,8 +115,8 @@ w_sg552_primary(player pl)
 	if (!pl.sg552_mag)
 		return;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 220);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 80,3)*pl.viewzoom;
 	pl.sg552_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -144,10 +144,13 @@ w_sg552_primary(player pl)
 	dmg = Skill_GetValue("plr_sg552_dmg", 33);
 	TraceAttack_SetRangeModifier(2.125);
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,1);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_SG552, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,1);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_sg552.fire");
 #endif
 
+	Cstrike_ShotMultiplierAdd(pl, 2.2, 0.9);
 	if (pl.viewzoom == 1.0f)
 		pl.w_attack_next = 0.0825f;
 	else

--- a/src/shared/w_tmp.qc
+++ b/src/shared/w_tmp.qc
@@ -115,8 +115,8 @@ w_tmp_primary(player pl)
 	if (!pl.tmp_mag)
 		return;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 40)+0.0085;
 	pl.tmp_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -144,10 +144,13 @@ w_tmp_primary(player pl)
 	dmg = Skill_GetValue("plr_tmp_dmg", 26);
 	TraceAttack_SetRangeModifier(1.25); /* 9 but not 10 */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,0.9);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_TMP, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,0.9);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_tmp.fire");
 #endif
 
+	Cstrike_ShotMultiplierAdd(pl, 0.7, 1.25);
 	pl.w_attack_next = 0.07f;
 	pl.w_idle_next = pl.w_attack_next;
 }

--- a/src/shared/w_tmp.qc
+++ b/src/shared/w_tmp.qc
@@ -144,13 +144,13 @@ w_tmp_primary(player pl)
 	dmg = Skill_GetValue("plr_tmp_dmg", 26);
 	TraceAttack_SetRangeModifier(1.25); /* 9 but not 10 */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,0.9);
+	Cstrike_BulletRecoil_ApplyPre(pl,0.8);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_TMP, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,0.9);
+	Cstrike_BulletRecoil_ApplyPost(pl,0.8);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_tmp.fire");
 #endif
 
-	Cstrike_ShotMultiplierAdd(pl, 0.8, 1.35);
+	Cstrike_ShotMultiplierAdd(pl, 0.85, 1.25);
 	pl.w_attack_next = 0.07f;
 	pl.w_idle_next = pl.w_attack_next;
 }

--- a/src/shared/w_tmp.qc
+++ b/src/shared/w_tmp.qc
@@ -116,7 +116,7 @@ w_tmp_primary(player pl)
 		return;
 
 
-	float accuracy = Cstrike_CalculateAccuracy(pl, 40)+0.0085;
+	float accuracy = Cstrike_CalculateAccuracy(pl, 30,0.8)+0.0035;
 	pl.tmp_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -150,7 +150,7 @@ w_tmp_primary(player pl)
 	Sound_Play(pl, CHAN_WEAPON, "weapon_tmp.fire");
 #endif
 
-	Cstrike_ShotMultiplierAdd(pl, 0.7, 1.25);
+	Cstrike_ShotMultiplierAdd(pl, 0.8, 1.35);
 	pl.w_attack_next = 0.07f;
 	pl.w_idle_next = pl.w_attack_next;
 }

--- a/src/shared/w_ump45.qc
+++ b/src/shared/w_ump45.qc
@@ -144,9 +144,9 @@ w_ump45_primary(player pl)
 	dmg = Skill_GetValue("plr_ump45_dmg", 30);
 	TraceAttack_SetRangeModifier(0.875); /* 6, but not 7 */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,1.2);
+	Cstrike_BulletRecoil_ApplyPre(pl,1.2);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_UMP45, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,1.2);
+	Cstrike_BulletRecoil_ApplyPost(pl,1.2);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_ump45.fire");
 #endif
 	Cstrike_ShotMultiplierAdd(pl, 1, .9);

--- a/src/shared/w_ump45.qc
+++ b/src/shared/w_ump45.qc
@@ -115,8 +115,8 @@ w_ump45_primary(player pl)
 	if (!pl.ump45_mag)
 		return;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 210);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl, 100,1)+0.003;
 	pl.ump45_mag--;
 
 	int r = (float)input_sequence % 3;
@@ -144,10 +144,12 @@ w_ump45_primary(player pl)
 	dmg = Skill_GetValue("plr_ump45_dmg", 30);
 	TraceAttack_SetRangeModifier(0.875); /* 6, but not 7 */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,1.2);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [accuracy,accuracy], WEAPON_UMP45, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,1.2);
 	Sound_Play(pl, CHAN_WEAPON, "weapon_ump45.fire");
 #endif
-
+	Cstrike_ShotMultiplierAdd(pl, 1, .9);
 	pl.w_attack_next = 0.105f;
 	pl.w_idle_next = pl.w_attack_next;
 }

--- a/src/shared/w_usp45.qc
+++ b/src/shared/w_usp45.qc
@@ -134,8 +134,8 @@ w_usp45_primary(player pl)
 	if (!pl.usp45_mag)
 		return;
 
-	Cstrike_ShotMultiplierAdd(pl, 1);
-	float accuracy = Cstrike_CalculateAccuracy(pl, 200);
+
+	float accuracy = Cstrike_CalculateAccuracy(pl,30,2);
 	int dmg = 0;
 	pl.usp45_mag--;
 
@@ -200,8 +200,11 @@ w_usp45_primary(player pl)
 	dmg = Skill_GetValue("plr_usp45_dmg", 33);
 	TraceAttack_SetRangeModifier(0.79); /* can penetrate 6 but not 7 units */
 	TraceAttack_SetPenetrationPower(1);
+	g_CstrikeBulletRecoil.ApplyPre(pl,0.625);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg,  [accuracy,accuracy], WEAPON_USP45, "Impact.BigShot");
+	g_CstrikeBulletRecoil.ApplyPost(pl,0.625);
 #endif
+	Cstrike_ShotMultiplierAdd(pl, 10, 0.4);
 
 	pl.gflags |= GF_SEMI_TOGGLED;
 	pl.w_attack_next = 0.15f;

--- a/src/shared/w_usp45.qc
+++ b/src/shared/w_usp45.qc
@@ -135,7 +135,7 @@ w_usp45_primary(player pl)
 		return;
 
 
-	float accuracy = Cstrike_CalculateAccuracy(pl,30,2);
+	float accuracy = Cstrike_CalculateAccuracy(pl,40,2.2);
 	int dmg = 0;
 	pl.usp45_mag--;
 
@@ -200,9 +200,9 @@ w_usp45_primary(player pl)
 	dmg = Skill_GetValue("plr_usp45_dmg", 33);
 	TraceAttack_SetRangeModifier(0.79); /* can penetrate 6 but not 7 units */
 	TraceAttack_SetPenetrationPower(1);
-	g_CstrikeBulletRecoil.ApplyPre(pl,0.625);
+	Cstrike_BulletRecoil_ApplyPre(pl,0.625);
 	TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg,  [accuracy,accuracy], WEAPON_USP45, "Impact.BigShot");
-	g_CstrikeBulletRecoil.ApplyPost(pl,0.625);
+	Cstrike_BulletRecoil_ApplyPost(pl,0.625);
 #endif
 	Cstrike_ShotMultiplierAdd(pl, 10, 0.4);
 

--- a/src/shared/w_xm1014.qc
+++ b/src/shared/w_xm1014.qc
@@ -206,7 +206,7 @@ w_xm1014_primary(player pl)
 #endif
 
 	for (int i = 0; i < 6; i++) {
-		Cstrike_ShotMultiplierAdd(pl, 1);
+		Cstrike_ShotMultiplierAdd(pl, 1, 1);
 		pl.punchangle[0] = -4 * (6 / 6);
 #ifdef SERVER
 		TraceAttack_FireBulletsWithDecal(1, pl.origin + pl.view_ofs, dmg, [random(-1,1) * 0.1,random(-1,1) * 0.05], WEAPON_M3, "Impact.BigShot");

--- a/src/shared/weapons_cstrike.qc
+++ b/src/shared/weapons_cstrike.qc
@@ -62,7 +62,7 @@ Cstrike_CalculateMovementInaccuracy(player pl) {
 
 /* called whenever a cstrike gun fires a successful shot */
 void
-Cstrike_ShotMultiplierAdd(player pl, int shots, float strength)
+Cstrike_ShotMultiplierAdd(player pl, float shots, float strength)
 {
 	int r;
 
@@ -74,7 +74,7 @@ Cstrike_ShotMultiplierAdd(player pl, int shots, float strength)
 		}
 	}
 	if (autocvar_guns_random_recoil_direction == 1) {
-		if (pseudorandom() > 0.83) {
+		if (pseudorandom() > 0.82f) {
 			pl.cs_hor_rec_sign = -pl.cs_hor_rec_sign;
 		}
 	} else {
@@ -86,8 +86,8 @@ Cstrike_ShotMultiplierAdd(player pl, int shots, float strength)
 		= pl.cs_shotmultiplier
 		+ 1.5
 		+ shots
-		+ pl.cs_shotmultiplier/5
-		- pl.cs_shotmultiplier*pl.cs_shotmultiplier/90;
+		+ pl.cs_shotmultiplier/6
+		- pl.cs_shotmultiplier*pl.cs_shotmultiplier/100;
 	pl.cs_shotmultiplier = bound(0, new_shotmultiplier, 30);
 	float bound_shotmultiplier = bound(0, pl.cs_shotmultiplier, 12);
 	pl.cs_shottime = 0.2f;
@@ -95,6 +95,12 @@ Cstrike_ShotMultiplierAdd(player pl, int shots, float strength)
 	float movement_inaccuracy = bound(0.92,Cstrike_CalculateMovementInaccuracy(pl),1.25);
 	pl.punchangle[0] = -(pl.cs_shotmultiplier)*0.3*movement_inaccuracy*strength+0.5;
 	pl.punchangle[0] *= autocvar_guns_recoil_strength;
+	if (pl.cs_shotmultiplier < 3) {
+		//here we add extra punchangle for low multiplier values,
+		//so that tapping has more weight to it.
+		float extrapunch = bound(0.7f,shots,1.5);
+		pl.punchangle[0] -= extrapunch;
+	}
 	float hor_recoil
 		= pl.cs_shotmultiplier*0.005
 		+ (pseudorandom() - 0.35)*0.75*autocvar_guns_firing_inaccuracy;
@@ -157,21 +163,19 @@ Cstrike_CalculateAccuracy(player pl, float divisor, float movement_penalty=1)
 	}
 }
 
-class CstrikeBulletRecoil {
-	private:
-		float m_flRandomSpread;
-	public:
-		void ApplyPre(player pl, float strength) {
-			m_flRandomSpread = (pseudorandom() - 0.5) * 2.0;
-			strength *= autocvar_guns_recoil_strength;
-			pl.v_angle += strength*pl.punchangle*(2 + pl.cs_shotmultiplier/100*(m_flRandomSpread-0.5));
-		};
-		void ApplyPost(player pl, float strength) {
-			strength *= autocvar_guns_recoil_strength;
-			pl.v_angle -= strength*pl.punchangle*(2 + pl.cs_shotmultiplier/100*(m_flRandomSpread-0.5));
-		};
-};
-CstrikeBulletRecoil g_CstrikeBulletRecoil;
+
+void
+Cstrike_BulletRecoil_ApplyPre(player pl, float strength) {
+	strength *= autocvar_guns_recoil_strength;
+	pl.v_angle += strength*pl.punchangle*(2 - pl.cs_shotmultiplier/100*0.2);
+}
+void
+Cstrike_BulletRecoil_ApplyPost(player pl, float strength) {
+	strength *= autocvar_guns_recoil_strength;
+	pl.v_angle -= strength*pl.punchangle*(2 - pl.cs_shotmultiplier/100*0.2);
+}
+
+
 /* called whenever cstrike guns aren't firing */
 void
 Cstrike_ShotMultiplierUpdate(player pl)
@@ -187,5 +191,6 @@ void
 w_cstrike_weaponrelease(void)
 {
 	player pl = (player)self;
+	pl.punchangle[1] *= 0.95;
 	Cstrike_ShotMultiplierUpdate(pl);
 }

--- a/src/shared/weapons_cstrike.qc
+++ b/src/shared/weapons_cstrike.qc
@@ -28,6 +28,11 @@
  * to other weapons.
 */
 
+var float autocvar_guns_recoil_strength = 1.0f;
+var bool autocvar_guns_random_recoil_direction = TRUE;
+var float autocvar_guns_movement_inaccuracy = 1.0f;
+var float autocvar_guns_firing_inaccuracy = 1.0f;
+
 weapontype_t
 csweapon_ranged_type(player pl)
 {
@@ -63,16 +68,20 @@ Cstrike_ShotMultiplierAdd(player pl, int shots, float strength)
 
 	if (pl.cs_shotmultiplier < 1.6) {
 		pl.cs_prev_hor_rec = 0;
-		if (pseudorandom() > 0.5) {
-			pl.cs_hor_rec_sign = 1;
-		} else {
+		pl.cs_hor_rec_sign = 1;
+		if (autocvar_guns_random_recoil_direction && pseudorandom() >= 0.5) {
 			pl.cs_hor_rec_sign = -1;
 		}
 	}
-	if (pseudorandom() > 0.83) {
-		pl.cs_hor_rec_sign = -pl.cs_hor_rec_sign;
+	if (autocvar_guns_random_recoil_direction == 1) {
+		if (pseudorandom() > 0.83) {
+			pl.cs_hor_rec_sign = -pl.cs_hor_rec_sign;
+		}
+	} else {
+		if ( pl.cs_shotmultiplier > 9) {
+			pl.cs_hor_rec_sign = -1;
+		}
 	}
-	/* more than 12 is enough, you can barely hit the barn */
 	float new_shotmultiplier
 		= pl.cs_shotmultiplier
 		+ 1.5
@@ -85,14 +94,17 @@ Cstrike_ShotMultiplierAdd(player pl, int shots, float strength)
 
 	float movement_inaccuracy = bound(0.92,Cstrike_CalculateMovementInaccuracy(pl),1.25);
 	pl.punchangle[0] = -(pl.cs_shotmultiplier)*0.3*movement_inaccuracy*strength+0.5;
+	pl.punchangle[0] *= autocvar_guns_recoil_strength;
 	float hor_recoil
 		= pl.cs_shotmultiplier*0.005
-		+ (pseudorandom() - 0.35)*0.75;
+		+ (pseudorandom() - 0.35)*0.75*autocvar_guns_firing_inaccuracy;
+
+	hor_recoil *= movement_inaccuracy * strength * autocvar_guns_recoil_strength;
 		
 	if (pl.cs_hor_rec_sign > 0) {
-		pl.cs_prev_hor_rec += hor_recoil*movement_inaccuracy*strength;
+		pl.cs_prev_hor_rec += hor_recoil;
 	} else if (pl.cs_hor_rec_sign < 0) {
-		pl.cs_prev_hor_rec -= hor_recoil*movement_inaccuracy*strength;
+		pl.cs_prev_hor_rec -= hor_recoil;
 	}
 	pl.punchangle[1] = pl.cs_prev_hor_rec;
 	r = (float)input_sequence % 5;
@@ -133,11 +145,11 @@ Cstrike_CalculateAccuracy(player pl, float divisor, float movement_penalty=1)
 		/* snipers shoot way less accurate overall. */
 		return (pl.viewzoom < 1.0f) ? (0.0f) : (0.05 * m);
 	} else {
-		inacc = pl.cs_shotmultiplier*pl.cs_shotmultiplier;
+		inacc = pl.cs_shotmultiplier*pl.cs_shotmultiplier * autocvar_guns_firing_inaccuracy;
 		inacc = inacc / divisor / 1000;
 		inacc = inacc * m;
 		if (m > 1) {
-			inacc += m * 0.0025*movement_penalty;
+			inacc += m * 0.0025*movement_penalty * autocvar_guns_movement_inaccuracy;
 		} else {
 			inacc += m * 0.0025;
 		}
@@ -151,9 +163,11 @@ class CstrikeBulletRecoil {
 	public:
 		void ApplyPre(player pl, float strength) {
 			m_flRandomSpread = (pseudorandom() - 0.5) * 2.0;
+			strength *= autocvar_guns_recoil_strength;
 			pl.v_angle += strength*pl.punchangle*(2 + pl.cs_shotmultiplier/100*(m_flRandomSpread-0.5));
 		};
 		void ApplyPost(player pl, float strength) {
+			strength *= autocvar_guns_recoil_strength;
 			pl.v_angle -= strength*pl.punchangle*(2 + pl.cs_shotmultiplier/100*(m_flRandomSpread-0.5));
 		};
 };

--- a/src/shared/weapons_cstrike.qc
+++ b/src/shared/weapons_cstrike.qc
@@ -40,20 +40,63 @@ csweapon_melee_type(player pl)
 	return WPNTYPE_CLOSE;
 }
 
+float
+Cstrike_CalculateMovementInaccuracy(player pl) {
+	float m = 1.0f;
+
+	if (!(pl.flags & FL_ONGROUND)) {
+		m = 2.5f;
+	} else if (pl.flags & FL_CROUCHING) {
+		m = 0.75f;
+	} else if (vlen(pl.velocity) > 120) {
+		m = 2.25f;
+	}
+
+	return m;
+}
+
 /* called whenever a cstrike gun fires a successful shot */
 void
-Cstrike_ShotMultiplierAdd(player pl, int shots)
+Cstrike_ShotMultiplierAdd(player pl, int shots, float strength)
 {
 	int r;
 
+	if (pl.cs_shotmultiplier < 1.6) {
+		pl.cs_prev_hor_rec = 0;
+		if (pseudorandom() > 0.5) {
+			pl.cs_hor_rec_sign = 1;
+		} else {
+			pl.cs_hor_rec_sign = -1;
+		}
+	}
+	if (pseudorandom() > 0.83) {
+		pl.cs_hor_rec_sign = -pl.cs_hor_rec_sign;
+	}
 	/* more than 12 is enough, you can barely hit the barn */
-	pl.cs_shotmultiplier = bound(0, pl.cs_shotmultiplier + shots, 12);
-
+	float new_shotmultiplier
+		= pl.cs_shotmultiplier
+		+ 1.5
+		+ shots
+		+ pl.cs_shotmultiplier/5
+		- pl.cs_shotmultiplier*pl.cs_shotmultiplier/90;
+	pl.cs_shotmultiplier = bound(0, new_shotmultiplier, 30);
+	float bound_shotmultiplier = bound(0, pl.cs_shotmultiplier, 12);
 	pl.cs_shottime = 0.2f;
-	pl.punchangle[0] = -4 * (pl.cs_shotmultiplier / 6);
 
+	float movement_inaccuracy = bound(0.92,Cstrike_CalculateMovementInaccuracy(pl),1.25);
+	pl.punchangle[0] = -(pl.cs_shotmultiplier)*0.3*movement_inaccuracy*strength+0.5;
+	float hor_recoil
+		= pl.cs_shotmultiplier*0.005
+		+ (pseudorandom() - 0.35)*0.75;
+		
+	if (pl.cs_hor_rec_sign > 0) {
+		pl.cs_prev_hor_rec += hor_recoil*movement_inaccuracy*strength;
+	} else if (pl.cs_hor_rec_sign < 0) {
+		pl.cs_prev_hor_rec -= hor_recoil*movement_inaccuracy*strength;
+	}
+	pl.punchangle[1] = pl.cs_prev_hor_rec;
 	r = (float)input_sequence % 5;
-	switch (r) {
+	/*switch (r) {
 	case 1:
 		pl.punchangle[1] = -0.1;
 		break;
@@ -72,32 +115,49 @@ Cstrike_ShotMultiplierAdd(player pl, int shots)
 	default:
 		pl.punchangle[1] = -0.5;
 		break;
-	}
+	}*/
 }
+
 
 
 /* generate an accuracy value that we'll pass onto TraceAttack */
 float
-Cstrike_CalculateAccuracy(player pl, float divisor)
+Cstrike_CalculateAccuracy(player pl, float divisor, float movement_penalty=1)
 {
-	float m = 1.0f;
-
-	if (!(pl.flags & FL_ONGROUND)) {
-		m = 2.0f;
-	} else if (pl.flags & FL_CROUCHING) {
-		m = 0.5f;
-	} else if (vlen(pl.velocity) > 120) {
-		m = 1.5f;
+	float inacc = 0;
+	float m = Cstrike_CalculateMovementInaccuracy(pl);
+	if (m > 1) {
+		m *= movement_penalty;
 	}
-
 	if (divisor == -1) {
 		/* snipers shoot way less accurate overall. */
 		return (pl.viewzoom < 1.0f) ? (0.0f) : (0.05 * m);
 	} else {
-		return  (pl.cs_shotmultiplier / divisor) * m;
+		inacc = pl.cs_shotmultiplier*pl.cs_shotmultiplier;
+		inacc = inacc / divisor / 1000;
+		inacc = inacc * m;
+		if (m > 1) {
+			inacc += m * 0.0025*movement_penalty;
+		} else {
+			inacc += m * 0.0025;
+		}
+		return inacc;
 	}
 }
 
+class CstrikeBulletRecoil {
+	private:
+		float m_flRandomSpread;
+	public:
+		void ApplyPre(player pl, float strength) {
+			m_flRandomSpread = (pseudorandom() - 0.5) * 2.0;
+			pl.v_angle += strength*pl.punchangle*(2 + pl.cs_shotmultiplier/100*(m_flRandomSpread-0.5));
+		};
+		void ApplyPost(player pl, float strength) {
+			pl.v_angle -= strength*pl.punchangle*(2 + pl.cs_shotmultiplier/100*(m_flRandomSpread-0.5));
+		};
+};
+CstrikeBulletRecoil g_CstrikeBulletRecoil;
 /* called whenever cstrike guns aren't firing */
 void
 Cstrike_ShotMultiplierUpdate(player pl)


### PR DESCRIPTION
The changes to the gunplay this rework entails are shown off in this [video](https://www.youtube.com/watch?v=F-AT1-uSL7M)

This is a rework of the recoil system in FreeCS. The hope is to bring it closer to the original feel of Counter-Strike. There are numerous changes to the system:

- `g_CstrikeBulletRecoil.ApplyPre(player pl, float strength)` and `g_CstrikeBulletRecoil.ApplyPost(player pl, float strength)`
Calls to these two functions are infixed between the `TraceAttack` in a weapon's fire routine. They apply the current value of the punchangle to player's `v_angle`, with a little randomness. A `float strength` value of 1 is enough for more guns, lower values are used for pistols and higher for high-recoil guns.

- `Cstrike_CalculateAccuracy()`'s internal calculation has been changed to return more extreme higher values (more inaccurate) the longer into the spray the player is. Lower values of the parameter `float divisor` should now be used. A new parameter, `float movement_penalty` has been added which amplifies the inaccuracy due to running or jumping (a value of 1 is used for SMG's, which can run and gun, whereas for rifles, >2 is used). To add extra first shot inaccuracy to the weapon, a constant is added to the return value of the function call (e.g. `accuracy = Cstrike_CalculateAccuracy(pl,20,1.5) + 0.003f`).

- Calls to `Cstrike_ShotMultiplierAdd()` have been moved to the bottom of weapon fire routines, *after* the call to TraceAttack. As well as that, a new parameter `float strength` has been added which allows for finer control of recoil feel. The function has been completely reworked to bring the feel of the recoil closer to the original. The algorithm uses two new member variables of the player: `float cs_hor_rec_sign`, which signifies which direction (left/right) the horizontal recoil is going, and `float cs_prev_hor_rec`, which is the previous value of the horizontal recoil.

-The punchangle recovery has been slightly modified. The important one is the recovery of the vertical recoil/punchangle. The new formula used to calculate the recovery is less sudden for very high vertical recoil compared to the original. This code had to be changed in the Nuclide source, so you can see it here: https://github.com/mikota/nuclide/commit/bde001b781fd69ae8f012bfa1d47842a32b6b258